### PR TITLE
feat: add Guida della Matricola page

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "check:fix": "biome check --write --unsafe"
   },
   "dependencies": {
-    "@polinetwork/backend": "^0.15.18",
+    "@polinetwork/backend": "^0.16.4",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@polinetwork/backend':
-        specifier: ^0.15.18
-        version: 0.15.18
+        specifier: ^0.16.4
+        version: 0.16.4
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -447,8 +447,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@polinetwork/backend@0.15.18':
-    resolution: {integrity: sha512-gT4TRMWIFNhwQi2mOx1OiH9HTP9BoorZHSvTti8vTCpk0qgKlL39ntAHQvFtDq1RbJ7rvS+DRd8fRBZkLVtOOw==}
+  '@polinetwork/backend@0.16.4':
+    resolution: {integrity: sha512-IspiFAA92uPfYHR2eKj3FCQxX8lVbvlL6lMmEFxEhJbIIaca3Fq1vduRlyDWSo7QC1bpXqzpjjVDUa/jrK+OtA==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1972,7 +1972,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.18':
     optional: true
 
-  '@polinetwork/backend@0.15.18': {}
+  '@polinetwork/backend@0.16.4': {}
 
   '@radix-ui/number@1.1.1': {}
 

--- a/src/app/matricole/guida/page.tsx
+++ b/src/app/matricole/guida/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next"
+import { FiDownload } from "react-icons/fi"
+import { CardSplit } from "@/components/card-split"
+import { Button } from "@/components/ui/button"
+import { getLatestGuidaMatricola } from "@/queries/guida-matricola"
+
+export const metadata: Metadata = {
+  title: "Guida della Matricola",
+  description: "Controlla l'ultima versione disponibile e scarica il PDF.",
+}
+
+export default async function GuidaMatricolaPage() {
+  const guida = await getLatestGuidaMatricola()
+  const formattedDate = new Intl.DateTimeFormat("it-IT", { dateStyle: "long" }).format(new Date(guida.publishedAt))
+
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-500 flex-col items-center justify-center gap-10 px-4 py-49">
+      <div className="mx-12 flex flex-col items-center gap-6">
+        <h2 className="typo-display-large lg:typo-display-extralarge w-fit bg-linear-to-b from-text-primary to-text-secondary bg-clip-text py-4 text-center text-transparent lg:leading-33">
+          Guida della Matricola
+        </h2>
+        <p className="typo-title-large lg:typo-headline-small max-w-4xl text-center">
+          Controlla l&apos;ultima versione disponibile e scarica il PDF aggiornato.
+        </p>
+      </div>
+      <CardSplit
+        textPrimary={`v${guida.version}`}
+        textSecondary="Versione Attuale"
+        textSecondarySmall={`Rilasciata il: ${formattedDate}`}
+        action={
+          <Button asChild size="icon-lg" aria-label="Scarica l'Ultima Versione">
+            <a href={guida.url} download>
+              <FiDownload />
+            </a>
+          </Button>
+        }
+      />
+    </main>
+  )
+}

--- a/src/app/matricole/guida/page.tsx
+++ b/src/app/matricole/guida/page.tsx
@@ -11,7 +11,9 @@ export const metadata: Metadata = {
 
 export default async function GuidaMatricolaPage() {
   const guida = await getLatestGuidaMatricola()
-  const formattedDate = new Intl.DateTimeFormat("it-IT", { dateStyle: "long" }).format(new Date(guida.publishedAt))
+  const formattedDate = guida
+    ? new Intl.DateTimeFormat("it-IT", { dateStyle: "long" }).format(new Date(guida.date))
+    : null
 
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-500 flex-col items-center justify-center gap-10 px-4 py-49">
@@ -23,18 +25,22 @@ export default async function GuidaMatricolaPage() {
           Controlla l&apos;ultima versione disponibile e scarica il PDF aggiornato.
         </p>
       </div>
-      <CardSplit
-        textPrimary={`v${guida.version}`}
-        textSecondary="Versione Attuale"
-        textSecondarySmall={`Rilasciata il: ${formattedDate}`}
-        action={
-          <Button asChild size="icon-lg" aria-label="Scarica l'Ultima Versione">
-            <a href={guida.url} download>
-              <FiDownload />
-            </a>
-          </Button>
-        }
-      />
+      {guida ? (
+        <CardSplit
+          textPrimary={guida.version}
+          textSecondary="Versione Attuale"
+          textSecondarySmall={`Rilasciata il: ${formattedDate}`}
+          action={
+            <Button asChild size="icon-lg" aria-label="Scarica l'Ultima Versione">
+              <a href={guida.url} download>
+                <FiDownload />
+              </a>
+            </Button>
+          }
+        />
+      ) : (
+        <p className="typo-body-large text-text-secondary">Nessuna guida disponibile al momento.</p>
+      )}
     </main>
   )
 }

--- a/src/components/card-split/index.tsx
+++ b/src/components/card-split/index.tsx
@@ -4,7 +4,7 @@ import { CardSplitPrimaryContent } from "./primary-content"
 import { CardSplitSecondaryContent } from "./secondary-content"
 import type { CardSplitProps } from "./types"
 
-export function CardSplit({ textPrimary, textSecondary, textSecondarySmall, className }: CardSplitProps) {
+export function CardSplit({ textPrimary, textSecondary, textSecondarySmall, action, className }: CardSplitProps) {
   const hasPrimaryContent = Boolean(textPrimary)
   const hasSecondaryContent = Boolean(textSecondary || textSecondarySmall)
 
@@ -15,16 +15,20 @@ export function CardSplit({ textPrimary, textSecondary, textSecondarySmall, clas
         className
       )}
     >
-      <div className="flex flex-col gap-10 px-10 py-5 sm:grid sm:grid-cols-[auto_auto] sm:items-center">
-        {textPrimary ? <CardSplitPrimaryContent text={textPrimary} /> : null}
+      <div className="flex flex-col items-center gap-10 px-10 py-5 sm:flex-row sm:items-center">
+        <div className="flex flex-col items-center gap-10 text-center sm:grid sm:grid-cols-[auto_auto] sm:items-center sm:text-left">
+          {textPrimary ? <CardSplitPrimaryContent text={textPrimary} /> : null}
 
-        {hasSecondaryContent && (
-          <CardSplitSecondaryContent
-            textSecondary={textSecondary}
-            textSecondarySmall={textSecondarySmall}
-            hasPrimaryContent={hasPrimaryContent}
-          />
-        )}
+          {hasSecondaryContent && (
+            <CardSplitSecondaryContent
+              textSecondary={textSecondary}
+              textSecondarySmall={textSecondarySmall}
+              hasPrimaryContent={hasPrimaryContent}
+            />
+          )}
+        </div>
+
+        {action && <div className="sm:ml-6">{action}</div>}
       </div>
     </Glass>
   )

--- a/src/components/card-split/types.ts
+++ b/src/components/card-split/types.ts
@@ -1,6 +1,9 @@
+import type { ReactNode } from "react"
+
 export type CardSplitProps = {
   textPrimary?: string
   textSecondary?: string
   textSecondarySmall?: string
+  action?: ReactNode
   className?: string
 }

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,11 +1,20 @@
 "use client"
 
+import { usePathname } from "next/navigation"
 import { DesktopLayout } from "./desktop-layout"
 import { MobileLayout } from "./mobile-layout"
 
 export type { HeaderMenuItem, HeaderSubmenuItem } from "./types"
 
+const HIDDEN_ROUTES = ["/matricole/guida"]
+
 export function Header() {
+  const pathname = usePathname()
+
+  if (HIDDEN_ROUTES.includes(pathname)) {
+    return null
+  }
+
   return (
     <>
       <div className="md:hidden">

--- a/src/components/matricole/constants.ts
+++ b/src/components/matricole/constants.ts
@@ -37,7 +37,7 @@ export const guides = [
     title: "Guida della matricola",
     description: "Dalla prima iscrizione alla vita in campus: il manuale completo per ogni nuovo studente.",
     icon: FiBook,
-    href: "/guides",
+    href: "/matricole/guida",
   },
   {
     title: "Mappa Microonde",

--- a/src/queries/guida-matricola.ts
+++ b/src/queries/guida-matricola.ts
@@ -1,0 +1,12 @@
+"use server"
+
+// TODO: sostituire questo
+const LATEST_GUIDA_MATRICOLA = {
+  version: "1.0.0",
+  publishedAt: "2025-09-01",
+  url: "/guides/guida-matricola.pdf",
+}
+
+export async function getLatestGuidaMatricola() {
+  return LATEST_GUIDA_MATRICOLA
+}

--- a/src/queries/guida-matricola.ts
+++ b/src/queries/guida-matricola.ts
@@ -3,7 +3,7 @@
 import { trpc } from "@/lib/backend"
 
 export async function getLatestGuidaMatricola() {
-  const guide = await trpc.web.guides_matricole.getLatestGuide.query()
+  const guide = await trpc.web.guides_matricole.getLatestGuide.query().catch(() => null)
   if (!guide) return null
 
   return { version: guide.version, date: guide.date, url: guide.file }

--- a/src/queries/guida-matricola.ts
+++ b/src/queries/guida-matricola.ts
@@ -1,12 +1,10 @@
 "use server"
 
-// TODO: sostituire questo
-const LATEST_GUIDA_MATRICOLA = {
-  version: "1.0.0",
-  publishedAt: "2025-09-01",
-  url: "/guides/guida-matricola.pdf",
-}
+import { trpc } from "@/lib/backend"
 
 export async function getLatestGuidaMatricola() {
-  return LATEST_GUIDA_MATRICOLA
+  const guide = await trpc.web.guides_matricole.getLatestGuide.query()
+  if (!guide) return null
+
+  return { version: guide.version, date: guide.date, url: guide.file }
 }


### PR DESCRIPTION
Introduce the Guida della Matricola page, which fetches the latest guide data from the backend and handles cases where no guide is available. Update the CardSplit component to support an action prop for enhanced functionality. Adjust routing for the guide and ensure the header is hidden on the guide page.